### PR TITLE
Adding Ben Craig

### DIFF
--- a/wg21_letter.adoc
+++ b/wg21_letter.adoc
@@ -66,3 +66,4 @@ René Ferdinand Rivera Morell (US - The C++ Alliance)
 Miro Knejp - {CPP} Consultant / Mentor / Engineer
 Jayesh Badwaik - {CPP} Developer
 Amin Yahyaabadi (@aminya) - Robotics Control Engineer
+Ben Craig - NI.  Vice Chair of WG21 Library Evolution


### PR DESCRIPTION
Adding under C++ Users on purpose.  Ben Craig is invited to WG21 meetings, but is not an official ISO member, or part of a National Body.